### PR TITLE
build(deps): bump python from 3.10.4-alpine3.15 to 3.10.5-alpine3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-alpine3.15
+FROM python:3.10.5-alpine3.15
 
 # Speedtest CLI Version
 ARG SPEEDTEST_VERSION=1.1.1


### PR DESCRIPTION
Bumps python from 3.10.4-alpine3.15 to 3.10.5-alpine3.15.

---
updated-dependencies:
- dependency-name: python
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>